### PR TITLE
Adit 241 spark hadoop upgrades

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val scalaSparkDepsVersion = Map(
     "3.2" -> Map(
       "akka" -> "2.6.17",
       "hadoop" -> "3.3.1",
-      "json4s" -> "3.6.12")
+      "json4s" -> "3.7.0-M11")
     )
   )
 
@@ -80,7 +80,7 @@ json4sVersion in ThisBuild := {
   sparkBinaryVersion.value match {
     case "2.0" | "2.1" | "2.2" | "2.3" => "3.2.11"
     case "2.4" => "3.5.3"
-    case "3.2" => "3.6.12"
+    case "3.2" => "3.7.0-M11"
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val scalaSparkDepsVersion = Map(
     "3.2" -> Map(
       "akka" -> "2.6.17",
       "hadoop" -> "3.3.1",
-      "json4s" -> "4.0.3")
+      "json4s" -> "3.6.12")
     )
   )
 
@@ -80,7 +80,7 @@ json4sVersion in ThisBuild := {
   sparkBinaryVersion.value match {
     case "2.0" | "2.1" | "2.2" | "2.3" => "3.2.11"
     case "2.4" => "3.5.3"
-    case "3.2" => "4.0.3"
+    case "3.2" => "3.6.12"
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,15 @@ lazy val scalaSparkDepsVersion = Map(
     "2.3" -> Map(
       "akka" -> "2.5.17",
       "hadoop" -> "2.7.7",
-      "json4s" -> "3.2.11")))
+      "json4s" -> "3.2.11")
+    ),
+  "2.12" -> Map(
+    "3.2" -> Map(
+      "akka" -> "2.6.17",
+      "hadoop" -> "3.3.1",
+      "json4s" -> "4.0.3")
+    )
+  )
 
 name := "apache-predictionio-parent"
 
@@ -41,7 +49,7 @@ version in ThisBuild := "0.15.0-SNAPSHOT"
 
 organization in ThisBuild := "org.apache.predictionio"
 
-scalaVersion in ThisBuild := sys.props.getOrElse("scala.version", "2.11.12")
+scalaVersion in ThisBuild := sys.props.getOrElse("scala.version", "2.12.8")
 
 scalaBinaryVersion in ThisBuild := binaryVersion(scalaVersion.value)
 
@@ -56,13 +64,13 @@ javacOptions in (ThisBuild, compile) ++= Seq("-source", "1.8", "-target", "1.8",
   "-Xlint:deprecation", "-Xlint:unchecked")
 
 // Ignore differentiation of Spark patch levels
-sparkVersion in ThisBuild := sys.props.getOrElse("spark.version", "2.1.3")
+sparkVersion in ThisBuild := sys.props.getOrElse("spark.version", "3.2.0")
 
 sparkBinaryVersion in ThisBuild := binaryVersion(sparkVersion.value)
 
-hadoopVersion in ThisBuild := sys.props.getOrElse("hadoop.version", "2.7.7")
+hadoopVersion in ThisBuild := sys.props.getOrElse("hadoop.version", "3.3.1")
 
-akkaVersion in ThisBuild := sys.props.getOrElse("akka.version", "2.5.17")
+akkaVersion in ThisBuild := sys.props.getOrElse("akka.version", "2.6.17")
 
 elasticsearchVersion in ThisBuild := sys.props.getOrElse("elasticsearch.version", "6.8.1")
 
@@ -72,6 +80,7 @@ json4sVersion in ThisBuild := {
   sparkBinaryVersion.value match {
     case "2.0" | "2.1" | "2.2" | "2.3" => "3.2.11"
     case "2.4" => "3.5.3"
+    case "3.2" => "4.0.3"
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,7 @@ hadoopVersion in ThisBuild := sys.props.getOrElse("hadoop.version", "3.3.1")
 
 akkaVersion in ThisBuild := sys.props.getOrElse("akka.version", "2.6.17")
 
-elasticsearchVersion in ThisBuild := sys.props.getOrElse("elasticsearch.version", "6.8.1")
+elasticsearchVersion in ThisBuild := sys.props.getOrElse("elasticsearch.version", "7.15.2")
 
 hbaseVersion in ThisBuild := sys.props.getOrElse("hbase.version", "1.2.6")
 

--- a/common/build.sbt
+++ b/common/build.sbt
@@ -22,9 +22,9 @@ name := "apache-predictionio-common"
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor"           % akkaVersion.value,
   "com.typesafe.akka" %% "akka-slf4j"           % akkaVersion.value,
-  "com.typesafe.akka" %% "akka-http"            % "10.1.5",
+  "com.typesafe.akka" %% "akka-http"            % "10.2.7",
   "org.json4s"        %% "json4s-native"        % json4sVersion.value,
-  "com.typesafe.akka" %% "akka-stream"          % "2.5.12"
+  "com.typesafe.akka" %% "akka-stream"          % "2.6.17"
 )
 
 pomExtra := childrenPomExtra.value

--- a/conf/pio-env.sh.template
+++ b/conf/pio-env.sh.template
@@ -24,7 +24,7 @@
 # you need to change these to fit your site.
 
 # SPARK_HOME: Apache Spark is a hard dependency and must be configured.
-SPARK_HOME=$PIO_HOME/vendors/spark-2.1.1-bin-hadoop2.6
+SPARK_HOME=$PIO_HOME/vendors/spark-3.2.0-bin-hadoop3.2
 
 POSTGRES_JDBC_DRIVER=$PIO_HOME/lib/postgresql-42.0.0.jar
 MYSQL_JDBC_DRIVER=$PIO_HOME/lib/mysql-connector-java-5.1.41.jar
@@ -88,7 +88,7 @@ PIO_STORAGE_SOURCES_PGSQL_PASSWORD=pio
 # PIO_STORAGE_SOURCES_ELASTICSEARCH_HOSTS=localhost
 # PIO_STORAGE_SOURCES_ELASTICSEARCH_PORTS=9200
 # PIO_STORAGE_SOURCES_ELASTICSEARCH_SCHEMES=http
-# PIO_STORAGE_SOURCES_ELASTICSEARCH_HOME=$PIO_HOME/vendors/elasticsearch-6.8.1
+# PIO_STORAGE_SOURCES_ELASTICSEARCH_HOME=$PIO_HOME/vendors/elasticsearch-7.15.2
 # Optional basic HTTP auth
 # PIO_STORAGE_SOURCES_ELASTICSEARCH_USERNAME=my-name
 # PIO_STORAGE_SOURCES_ELASTICSEARCH_PASSWORD=my-secret

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -22,15 +22,15 @@ name := "apache-predictionio-core"
 libraryDependencies ++= Seq(
   "com.github.scopt"       %% "scopt"            % "3.5.0",
   "com.google.code.gson"    % "gson"             % "2.5",
-  "com.twitter"            %% "chill-bijection"  % "0.7.2",
+  "com.twitter"            %% "chill-bijection"  % "0.10.0",
   "de.javakaffee"           % "kryo-serializers" % "0.37",
   "net.jodah"               % "typetools"        % "0.3.1",
   "org.apache.spark"       %% "spark-core"       % sparkVersion.value % "provided",
   "org.json4s"             %% "json4s-ext"       % json4sVersion.value,
-  "org.scalaj"             %% "scalaj-http"      % "1.1.6",
+  "org.scalaj"             %% "scalaj-http"      % "2.4.2",
   "org.slf4j"               % "slf4j-log4j12"    % "1.7.18",
-  "org.scalatest"          %% "scalatest"        % "2.1.7" % "test",
-  "org.specs2"             %% "specs2"           % "2.3.13" % "test",
+  "org.scalatest"          %% "scalatest"        % "3.2.10" % "test",
+  "org.specs2"             %% "specs2-core"           % "4.13.0" % "test",
   "org.scalamock"          %% "scalamock-scalatest-support" % "3.5.0" % "test",
   "com.h2database"           % "h2"             % "1.4.196" % "test"
 )

--- a/data/build.sbt
+++ b/data/build.sbt
@@ -21,13 +21,13 @@ name := "apache-predictionio-data"
 
 libraryDependencies ++= Seq(
   "org.scala-lang"          % "scala-reflect"  % scalaVersion.value,
-  "com.github.nscala-time" %% "nscala-time"    % "2.6.0",
+  "com.github.nscala-time" %% "nscala-time"    % "2.30.0",
   "com.google.guava"        % "guava"          % "14.0.1",
   "com.typesafe.akka"      %% "akka-http-testkit" % "10.1.5" % "test",
   "org.apache.spark"       %% "spark-sql"      % sparkVersion.value % "provided",
-  "org.clapper"            %% "grizzled-slf4j" % "1.0.2",
-  "org.scalatest"          %% "scalatest"      % "2.1.7" % "test",
-  "org.specs2"             %% "specs2"         % "3.3.1" % "test"
+  "org.clapper"            %% "grizzled-slf4j" % "1.3.4",
+  "org.scalatest"          %% "scalatest"      % "3.2.10" % "test",
+  "org.specs2"             %% "specs2-core"         % "4.13.0" % "test"
     exclude("org.scalaz.stream", s"scalaz-stream_${scalaBinaryVersion.value}"),
   "org.scalamock"          %% "scalamock-specs2-support" % "3.5.0" % "test",
   "com.h2database"           % "h2"             % "1.4.196" % "test")

--- a/e2/build.sbt
+++ b/e2/build.sbt
@@ -23,6 +23,6 @@ parallelExecution in Test := false
 
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-mllib" % sparkVersion.value % "provided",
-  "org.scalatest"    %% "scalatest" % "2.2.5" % "test")
+  "org.scalatest"    %% "scalatest" % "3.2.10" % "test")
 
 pomExtra := childrenPomExtra.value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,3 +15,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.22")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-license-report" % "1.2.0")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/sbt/sbt
+++ b/sbt/sbt
@@ -8,7 +8,8 @@ set -o pipefail
 declare -r sbt_release_version="0.13.13"
 declare -r sbt_unreleased_version="0.13.13"
 
-declare -r latest_212="2.12.1"
+declare -r latest_213="2.13.7"
+declare -r latest_212="2.12.8"
 declare -r latest_211="2.11.8"
 declare -r latest_210="2.10.6"
 declare -r latest_29="2.9.3"
@@ -16,10 +17,10 @@ declare -r latest_28="2.8.2"
 
 declare -r buildProps="project/build.properties"
 
-declare -r sbt_launch_ivy_release_repo="http://repo.typesafe.com/typesafe/ivy-releases"
+declare -r sbt_launch_ivy_release_repo="https://repo.typesafe.com/typesafe/ivy-releases"
 declare -r sbt_launch_ivy_snapshot_repo="https://repo.scala-sbt.org/scalasbt/ivy-snapshots"
-declare -r sbt_launch_mvn_release_repo="http://repo.scala-sbt.org/scalasbt/maven-releases"
-declare -r sbt_launch_mvn_snapshot_repo="http://repo.scala-sbt.org/scalasbt/maven-snapshots"
+declare -r sbt_launch_mvn_release_repo="https://repo.scala-sbt.org/scalasbt/maven-releases"
+declare -r sbt_launch_mvn_snapshot_repo="https://repo.scala-sbt.org/scalasbt/maven-snapshots"
 
 declare -r default_jvm_opts_common="-Xms512m -Xmx1536m -Xss2m"
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
@@ -119,7 +120,7 @@ url_base () {
   local version="$1"
 
   case "$version" in
-        0.7.*) echo "http://simple-build-tool.googlecode.com" ;;
+        0.7.*) echo "https://simple-build-tool.googlecode.com" ;;
       0.10.* ) echo "$sbt_launch_ivy_release_repo" ;;
     0.11.[12]) echo "$sbt_launch_ivy_release_repo" ;;
     0.*-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]) # ie "*-yyyymmdd-hhMMss"
@@ -320,6 +321,7 @@ runner with the -x option.
   -210                      use $latest_210
   -211                      use $latest_211
   -212                      use $latest_212
+  -213                      use $latest_213
   -scala-home <path>        use the scala build at the specified directory
   -scala-version <version>  use the specified version of scala
   -binary-version <version> use the specified scala version when searching for dependencies
@@ -399,6 +401,7 @@ process_args () {
               -210) setScalaVersion "$latest_210" && shift ;;
               -211) setScalaVersion "$latest_211" && shift ;;
               -212) setScalaVersion "$latest_212" && shift ;;
+              -213) setScalaVersion "$latest_213" && shift ;;
                new) sbt_new=true && sbt_explicit_version="$sbt_release_version"  && addResidual "$1" && shift ;;
                  *) addResidual "$1" && shift ;;
     esac

--- a/storage/elasticsearch/build.sbt
+++ b/storage/elasticsearch/build.sbt
@@ -23,9 +23,9 @@ libraryDependencies ++= Seq(
   "org.apache.predictionio" %% "apache-predictionio-core"  % version.value % "provided",
   "org.apache.spark"        %% "spark-core"                % sparkVersion.value % "provided",
   "org.elasticsearch.client" % "elasticsearch-rest-client" % elasticsearchVersion.value,
-  "org.elasticsearch"       %% "elasticsearch-spark-20"    % elasticsearchVersion.value
+  "org.elasticsearch"       %% "elasticsearch-spark-30"    % elasticsearchVersion.value
     exclude("org.apache.spark", "*"),
-  "org.specs2"              %% "specs2"                    % "2.3.13" % "test")
+  "org.specs2"              %% "specs2-core"                    % "4.2.0" % "test")
 
 parallelExecution in Test := false
 

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESAccessKeys.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESAccessKeys.scala
@@ -28,6 +28,7 @@ import org.apache.predictionio.data.storage.AccessKey
 import org.apache.predictionio.data.storage.AccessKeys
 import org.apache.predictionio.data.storage.StorageClientConfig
 import org.elasticsearch.client.{ResponseException, RestClient}
+import org.elasticsearch.client.Request
 import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.native.JsonMethods._
@@ -62,10 +63,9 @@ class ESAccessKeys(client: RestClient, config: StorageClientConfig, metadataName
       return None
     }
     try {
-      val response = client.performRequest(
-        "GET",
-        s"/$index/$estype/$id",
-        Map.empty[String, String].asJava)
+      val request = new Request("GET", s"/$index/$estype/$id")
+      request.addParameters(Map.empty[String, String].asJava)
+      val response = client.performRequest(request)
       val jsonResponse = parse(EntityUtils.toString(response.getEntity))
       (jsonResponse \ "found").extract[Boolean] match {
         case true =>
@@ -118,11 +118,10 @@ class ESAccessKeys(client: RestClient, config: StorageClientConfig, metadataName
     val id = accessKey.key
     try {
       val entity = new NStringEntity(write(accessKey), ContentType.APPLICATION_JSON)
-      val response = client.performRequest(
-        "PUT",
-        s"/$index/$estype/$id",
-        Map("refresh" -> "true").asJava,
-        entity)
+      val request = new Request("PUT", s"/$index/$estype/$id")
+      request.addParameters(Map("refresh" -> "true").asJava)
+      request.setEntity(entity)
+      val response = client.performRequest(request)
       val jsonResponse = parse(EntityUtils.toString(response.getEntity))
       val result = (jsonResponse \ "result").extract[String]
       result match {
@@ -139,10 +138,9 @@ class ESAccessKeys(client: RestClient, config: StorageClientConfig, metadataName
 
   def delete(id: String): Unit = {
     try {
-      val response = client.performRequest(
-        "DELETE",
-        s"/$index/$estype/$id",
-        Map("refresh" -> "true").asJava)
+      val request = new Request("DELETE", s"/$index/$estype/$id")
+      request.addParameters(Map("refresh" -> "true").asJava)
+      val response = client.performRequest(request)
       val json = parse(EntityUtils.toString(response.getEntity))
       val result = (json \ "result").extract[String]
       result match {

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESChannels.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESChannels.scala
@@ -28,6 +28,7 @@ import org.apache.predictionio.data.storage.Channel
 import org.apache.predictionio.data.storage.Channels
 import org.apache.predictionio.data.storage.StorageClientConfig
 import org.elasticsearch.client.{ResponseException, RestClient}
+import org.elasticsearch.client.Request
 import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.native.JsonMethods._
@@ -69,10 +70,9 @@ class ESChannels(client: RestClient, config: StorageClientConfig, metadataName: 
 
   def get(id: Int): Option[Channel] = {
     try {
-      val response = client.performRequest(
-        "GET",
-        s"/$index/$estype/$id",
-        Map.empty[String, String].asJava)
+      val request = new Request("GET", s"/$index/$estype/$id")
+      request.addParameters(Map.empty[String, String].asJava)
+      val response = client.performRequest(request)
       val jsonResponse = parse(EntityUtils.toString(response.getEntity))
       (jsonResponse \ "found").extract[Boolean] match {
         case true =>
@@ -112,11 +112,10 @@ class ESChannels(client: RestClient, config: StorageClientConfig, metadataName: 
     val id = channel.id.toString
     try {
       val entity = new NStringEntity(write(channel), ContentType.APPLICATION_JSON)
-      val response = client.performRequest(
-        "PUT",
-        s"/$index/$estype/$id",
-        Map("refresh" -> "true").asJava,
-        entity)
+      val request = new Request("PUT", s"/$index/$estype/$id")
+      request.addParameters(Map("refresh" -> "true").asJava)
+      request.setEntity(entity)
+      val response = client.performRequest(request)
       val json = parse(EntityUtils.toString(response.getEntity))
       val result = (json \ "result").extract[String]
       result match {
@@ -135,10 +134,9 @@ class ESChannels(client: RestClient, config: StorageClientConfig, metadataName: 
 
   def delete(id: Int): Unit = {
     try {
-      val response = client.performRequest(
-        "DELETE",
-        s"/$index/$estype/$id",
-        Map("refresh" -> "true").asJava)
+      val request = new Request("DELETE", s"/$index/$estype/$id")
+      request.addParameters(Map("refresh" -> "true").asJava)
+      val response = client.performRequest(request)
       val jsonResponse = parse(EntityUtils.toString(response.getEntity))
       val result = (jsonResponse \ "result").extract[String]
       result match {

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESEngineInstances.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESEngineInstances.scala
@@ -29,6 +29,7 @@ import org.apache.predictionio.data.storage.EngineInstanceSerializer
 import org.apache.predictionio.data.storage.EngineInstances
 import org.apache.predictionio.data.storage.StorageClientConfig
 import org.elasticsearch.client.{ResponseException, RestClient}
+import org.elasticsearch.client.Request
 import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.native.JsonMethods._
@@ -83,11 +84,10 @@ class ESEngineInstances(client: RestClient, config: StorageClientConfig, metadat
   def preInsert(): Option[String] = {
     try {
       val entity = new NStringEntity("{}", ContentType.APPLICATION_JSON)
-      val response = client.performRequest(
-        "POST",
-        s"/$index/$estype",
-        Map("refresh" -> "true").asJava,
-        entity)
+      val request = new Request("POST", s"/$index/$estype")
+      request.addParameters(Map("refresh" -> "true").asJava)
+      request.setEntity(entity)
+      val response = client.performRequest(request)
       val jsonResponse = parse(EntityUtils.toString(response.getEntity))
       val result = (jsonResponse \ "result").extract[String]
       result match {
@@ -106,10 +106,9 @@ class ESEngineInstances(client: RestClient, config: StorageClientConfig, metadat
 
   def get(id: String): Option[EngineInstance] = {
     try {
-      val response = client.performRequest(
-        "GET",
-        s"/$index/$estype/$id",
-        Map.empty[String, String].asJava)
+      val request = new Request("GET", s"/$index/$estype/$id")
+      request.addParameters(Map.empty[String, String].asJava)
+      val response = client.performRequest(request)
       val jsonResponse = parse(EntityUtils.toString(response.getEntity))
       (jsonResponse \ "found").extract[Boolean] match {
         case true =>
@@ -185,11 +184,10 @@ class ESEngineInstances(client: RestClient, config: StorageClientConfig, metadat
     val id = i.id
     try {
       val entity = new NStringEntity(write(i), ContentType.APPLICATION_JSON)
-      val response = client.performRequest(
-        "PUT",
-        s"/$index/$estype/$id",
-        Map("refresh" -> "true").asJava,
-        entity)
+      val request = new Request("PUT", s"/$index/$estype/$id")
+      request.addParameters(Map("refresh" -> "true").asJava)
+      request.setEntity(entity)
+      val response = client.performRequest(request)
       val jsonResponse = parse(EntityUtils.toString(response.getEntity))
       val result = (jsonResponse \ "result").extract[String]
       result match {
@@ -206,10 +204,9 @@ class ESEngineInstances(client: RestClient, config: StorageClientConfig, metadat
 
   def delete(id: String): Unit = {
     try {
-      val response = client.performRequest(
-        "DELETE",
-        s"/$index/$estype/$id",
-        Map("refresh" -> "true").asJava)
+      val request = new Request("DELETE", s"/$index/$estype/$id")
+      request.addParameters(Map("refresh" -> "true").asJava)
+      val response = client.performRequest(request)
       val json = parse(EntityUtils.toString(response.getEntity))
       val result = (json \ "result").extract[String]
       result match {

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESEvaluationInstances.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESEvaluationInstances.scala
@@ -29,6 +29,7 @@ import org.apache.predictionio.data.storage.EvaluationInstanceSerializer
 import org.apache.predictionio.data.storage.EvaluationInstances
 import org.apache.predictionio.data.storage.StorageClientConfig
 import org.elasticsearch.client.{ResponseException, RestClient}
+import org.elasticsearch.client.Request
 import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.native.JsonMethods._
@@ -78,10 +79,9 @@ class ESEvaluationInstances(client: RestClient, config: StorageClientConfig, met
 
   def get(id: String): Option[EvaluationInstance] = {
     try {
-      val response = client.performRequest(
-        "GET",
-        s"/$index/$estype/$id",
-        Map.empty[String, String].asJava)
+      val request = new Request("GET", s"/$index/$estype/$id")
+      request.addParameters(Map.empty[String, String].asJava)
+      val response = client.performRequest(request)
       val jsonResponse = parse(EntityUtils.toString(response.getEntity))
       (jsonResponse \ "found").extract[Boolean] match {
         case true =>
@@ -137,11 +137,10 @@ class ESEvaluationInstances(client: RestClient, config: StorageClientConfig, met
     val id = i.id
     try {
       val entity = new NStringEntity(write(i), ContentType.APPLICATION_JSON)
-      val response = client.performRequest(
-        "PUT",
-        s"/$index/$estype/$id",
-        Map("refresh" -> "true").asJava,
-        entity)
+      val request = new Request("PUT", s"/$index/$estype/$id")
+      request.addParameters(Map("refresh" -> "true").asJava)
+      request.setEntity(entity)
+      val response = client.performRequest(request)
       val json = parse(EntityUtils.toString(response.getEntity))
       val result = (json \ "result").extract[String]
       result match {
@@ -158,10 +157,9 @@ class ESEvaluationInstances(client: RestClient, config: StorageClientConfig, met
 
   def delete(id: String): Unit = {
     try {
-      val response = client.performRequest(
-        "DELETE",
-        s"/$index/$estype/$id",
-        Map("refresh" -> "true").asJava)
+      val request = new Request("DELETE", s"/$index/$estype/$id")
+      request.addParameters(Map("refresh" -> "true").asJava)
+      val response = client.performRequest(request)
       val json = parse(EntityUtils.toString(response.getEntity))
       val result = (json \ "result").extract[String]
       result match {

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESSequences.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESSequences.scala
@@ -27,6 +27,7 @@ import org.apache.http.util.EntityUtils
 import org.apache.predictionio.data.storage.StorageClientConfig
 import org.apache.predictionio.data.storage.StorageClientException
 import org.elasticsearch.client.RestClient
+import org.elasticsearch.client.Request
 import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.native.JsonMethods._
@@ -50,11 +51,10 @@ class ESSequences(client: RestClient, config: StorageClientConfig, metadataName:
   def genNext(name: String): Long = {
     try {
       val entity = new NStringEntity(write("n" -> name), ContentType.APPLICATION_JSON)
-      val response = client.performRequest(
-        "PUT",
-        s"/$index/$estype/$name",
-        Map("refresh" -> "false").asJava,
-        entity)
+      val request = new Request("PUT", s"/$index/$estype/$name")
+      request.addParameters(Map("refresh" -> "false").asJava)
+      request.setEntity(entity)
+      val response = client.performRequest(request)
       val jsonResponse = parse(EntityUtils.toString(response.getEntity))
       val result = (jsonResponse \ "result").extract[String]
       result match {

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/StorageClient.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/StorageClient.scala
@@ -27,6 +27,7 @@ import org.apache.predictionio.data.storage.StorageClientException
 import org.apache.predictionio.workflow.CleanupFunctions
 import org.elasticsearch.client.RestClient
 import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback
+import org.elasticsearch.client.Request
 
 import grizzled.slf4j.Logging
 

--- a/storage/hbase/build.sbt
+++ b/storage/hbase/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
     exclude("org.mortbay.jetty", "servlet-api-2.5")
     exclude("org.mortbay.jetty", "jsp-api-2.1")
     exclude("org.mortbay.jetty", "jsp-2.1"),
-  "org.specs2"              %% "specs2"         % "2.3.13" % "test")
+  "org.specs2"              %% "specs2-core"         % "4.2.0" % "test")
 
 parallelExecution in Test := false
 

--- a/storage/hdfs/build.sbt
+++ b/storage/hdfs/build.sbt
@@ -22,22 +22,20 @@ name := "apache-predictionio-data-hdfs"
 libraryDependencies ++= Seq(
   "org.apache.hadoop"        % "hadoop-common"            % hadoopVersion.value
     exclude("commons-beanutils", "*")
-    exclude("jakarta.activation", "*")
-    exclude("com.fasterxml.jackson.core", "*")
-    exclude("org.codehaus.woodstox", "stax2-api"),
-  "org.apache.hadoop"        % "hadoop-hdfs"              % hadoopVersion.value
-    exclude("com.fasterxml.jackson.core", "*"),
+    exclude("jakarta.activation", "*"),
+  "org.apache.hadoop"        % "hadoop-hdfs"              % hadoopVersion.value,
   "org.apache.predictionio" %% "apache-predictionio-data" % version.value % "provided",
   "org.scalatest"           %% "scalatest"                % "3.2.10" % "test")
 
-/*assemblyMergeStrategy in assembly := {
-  case PathList("javax", "activation") => MergeStrategy.discard
-  case PathList("jakarta", "activation") => MergeStrategy.discard
+// jackson (and a couple other libraries) causes problems during deduplication phase of module-info.class -
+// files apparently not needed, so discard them to avoid error
+assemblyMergeStrategy in assembly := {
+  case PathList("module-info.class") => MergeStrategy.discard
+  case PathList("META-INF", "versions", xs @ _, "module-info.class") => MergeStrategy.discard
   case x =>
     val oldStrategy = (assemblyMergeStrategy in assembly).value
     oldStrategy(x)
-}*/
-
+}
 parallelExecution in Test := false
 
 pomExtra := childrenPomExtra.value

--- a/storage/hdfs/build.sbt
+++ b/storage/hdfs/build.sbt
@@ -27,9 +27,15 @@ libraryDependencies ++= Seq(
   "org.apache.predictionio" %% "apache-predictionio-data" % version.value % "provided",
   "org.scalatest"           %% "scalatest"                % "3.2.10" % "test")
 
+// making sure the needed netty version gets pulled for this subproject
+dependencyOverrides ++= Seq(
+  "io.netty"                 % "netty-all"                % "4.1.42.Final"
+)
+
 // jackson (and a couple other libraries) causes problems during deduplication phase of module-info.class -
 // files apparently not needed, so discard them to avoid error
 assemblyMergeStrategy in assembly := {
+  case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first
   case PathList("module-info.class") => MergeStrategy.discard
   case PathList("META-INF", "versions", xs @ _, "module-info.class") => MergeStrategy.discard
   case x =>

--- a/storage/hdfs/build.sbt
+++ b/storage/hdfs/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
     exclude("commons-beanutils", "*"),
   "org.apache.hadoop"        % "hadoop-hdfs"              % hadoopVersion.value,
   "org.apache.predictionio" %% "apache-predictionio-data" % version.value % "provided",
-  "org.scalatest"           %% "scalatest"                % "2.1.7" % "test")
+  "org.scalatest"           %% "scalatest"                % "3.2.10" % "test")
 
 parallelExecution in Test := false
 

--- a/storage/hdfs/build.sbt
+++ b/storage/hdfs/build.sbt
@@ -21,10 +21,22 @@ name := "apache-predictionio-data-hdfs"
 
 libraryDependencies ++= Seq(
   "org.apache.hadoop"        % "hadoop-common"            % hadoopVersion.value
-    exclude("commons-beanutils", "*"),
-  "org.apache.hadoop"        % "hadoop-hdfs"              % hadoopVersion.value,
+    exclude("commons-beanutils", "*")
+    exclude("jakarta.activation", "*")
+    exclude("com.fasterxml.jackson.core", "*")
+    exclude("org.codehaus.woodstox", "stax2-api"),
+  "org.apache.hadoop"        % "hadoop-hdfs"              % hadoopVersion.value
+    exclude("com.fasterxml.jackson.core", "*"),
   "org.apache.predictionio" %% "apache-predictionio-data" % version.value % "provided",
   "org.scalatest"           %% "scalatest"                % "3.2.10" % "test")
+
+/*assemblyMergeStrategy in assembly := {
+  case PathList("javax", "activation") => MergeStrategy.discard
+  case PathList("jakarta", "activation") => MergeStrategy.discard
+  case x =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(x)
+}*/
 
 parallelExecution in Test := false
 

--- a/storage/jdbc/build.sbt
+++ b/storage/jdbc/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark"        %% "spark-sql"      % sparkVersion.value % "provided",
   "org.scalikejdbc"         %% "scalikejdbc"    % "3.1.0",
   "org.postgresql"           % "postgresql"     % "9.4-1204-jdbc41" % "test",
-  "org.specs2"              %% "specs2"         % "2.3.13" % "test")
+  "org.specs2"              %% "specs2-core"         % "4.2.0" % "test")
 
 parallelExecution in Test := false
 

--- a/storage/localfs/build.sbt
+++ b/storage/localfs/build.sbt
@@ -21,7 +21,7 @@ name := "apache-predictionio-data-localfs"
 
 libraryDependencies ++= Seq(
   "org.apache.predictionio" %% "apache-predictionio-core" % version.value % "provided",
-  "org.scalatest"           %% "scalatest"      % "2.1.7" % "test")
+  "org.scalatest"           %% "scalatest"      % "3.2.10" % "test")
 
 parallelExecution in Test := false
 

--- a/storage/s3/build.sbt
+++ b/storage/s3/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "org.apache.predictionio" %% "apache-predictionio-core" % version.value % "provided",
   "com.google.guava"        % "guava"                     % "14.0.1"      % "provided",
   "com.amazonaws"           % "aws-java-sdk-s3"           % "1.11.132",
-  "org.scalatest"           %% "scalatest"                % "2.1.7" % "test")
+  "org.scalatest"           %% "scalatest"                % "3.2.10" % "test")
 
 parallelExecution in Test := false
 

--- a/tools/build.sbt
+++ b/tools/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "com.github.zafarkhaja"  %  "java-semver"       % "0.9.0",
   "org.apache.spark"       %% "spark-sql"         % sparkVersion.value % "provided",
   "com.typesafe.akka"      %% "akka-slf4j"        % akkaVersion.value,
-  "com.typesafe.akka"      %% "akka-http-testkit" % "10.1.5" % "test",
+  "com.typesafe.akka"      %% "akka-http-testkit" % "10.2.7" % "test",
   "org.specs2"             %% "specs2-core"       % "4.2.0" % "test")
 
 assemblyMergeStrategy in assembly := {

--- a/tools/src/main/scala/org/apache/predictionio/tools/admin/AdminAPI.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/admin/AdminAPI.scala
@@ -55,7 +55,11 @@ object AdminServer {
       complete(StatusCodes.NotFound,
         Map("message" -> s"missing required query parameter ${msg}."))
     case AuthenticationFailedRejection(cause, challengeHeaders) =>
-      complete(StatusCodes.Unauthorized, challengeHeaders,
+      // TODO: updating akka seems to have caused problems with putting challengeHeaders into 
+      // the response, see if that can/needs to be fixed
+      // complete(StatusCodes.Unauthorized, challengeHeaders,
+      //   Map("message" -> s"Invalid accessKey."))
+      complete(StatusCodes.Unauthorized,
         Map("message" -> s"Invalid accessKey."))
   }.result()
 


### PR DESCRIPTION
Updating predictionio to use the newest versions of Spark (3.2.0) and Hadoop (3.3.1), along with fixing library incompatibilities as necessary.